### PR TITLE
Add optionalOptions to bake()

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ _(NOTE: this is functionally identical to calling `this.get('cookieMonster.cooki
 var cookieValue = this.get('cookieMonster').eat('cookie-value');
 // does not touch or parse `document.cookie`!
 ```
-### `#.bake(key, value, days)`
+### `#.bake(key, value, days, optionalOptions)`
 ##### Set a cookie value for an optional amount of days:
 ```javascript
   cookieMonster: Ember.inject.service(),
@@ -71,7 +71,7 @@ var cookieValue = this.get('cookieMonster').eat('cookie-value');
       // remember user preference for 10 days
       // sets the cookie expiration date for 10 days in the future
       var days = 10;
-      this.get('cookieMonster').bake(preference, value, days)
+      this.get('cookieMonster').bake(preference, value, days, { domain: 'scott.com' })
     }
   }
 });

--- a/addon/services/cookie-monster.js
+++ b/addon/services/cookie-monster.js
@@ -33,23 +33,37 @@ export default Ember.Service.extend({
     return this.get('cookies.' + key);
   },
 
-  _gatherIngredients(key, value, days) {
-    var expires = '';
-    if (days) {
-      var date = new Date();
-      date.setDate(date.getDate() + days);
-      expires = '; expires=' + date.toGMTString();
+  _gatherIngredients(key, value, days, options = {}) {
+    var ingredients = [`${encodeURIComponent(key)}=${encodeURIComponent(value)}`];
+
+    if(!options['path']) {
+      options['path'] = '/';
     }
-    return [encodeURIComponent(key), '=', encodeURIComponent(value), expires, '; path=/'].join('');
+
+    if(!options['expires']) {
+      if(days) {
+        var date = new Date();
+        date.setDate(date.getDate() + days);
+        options['expires'] = date.toGMTString();
+      } else {
+        options['expires'] = '';
+      }
+    }
+
+    let optionalIngredients = Ember.keys(options).map(function(optionKey) {
+      return `${optionKey}=${options[optionKey]}`;
+    });
+
+    return ingredients.concat(optionalIngredients).join('; ');
   },
 
   _putInOven(cookie) {
     document.cookie = cookie;
   },
 
-  bake(key, value, days) {
+  bake(key, value, days, options = {}) {
     this.set('cookies.' + key, value);
-    var ingredients = this._gatherIngredients(key, value, days);
+    var ingredients = this._gatherIngredients(key, value, days, options);
     this._putInOven(ingredients);
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cookie-monster",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Bind attributes to cookie values in Ember.",
   "directories": {
     "test": "tests"

--- a/tests/unit/services/cookie-monster-test.js
+++ b/tests/unit/services/cookie-monster-test.js
@@ -45,6 +45,20 @@ test('cookies can be baked', function(assert) {
   assert.equal(service.get('cookies.queens'), 'js', 'queens IS js');
 });
 
+test('cookies can accept optional options', function(assert) {
+  assert.expect(4);
+  var service = this.subject({
+    _putInOven(cookie) {
+      assert.ok(/username=scott/.test(cookie), 'actual cookie value is set');
+      assert.ok(/domain=scott\.com/.test(cookie), 'domain for cookie is set');
+      assert.ok(/path=\/user/.test(cookie), 'path for cookie is set');
+    }
+  });
+
+  service.bake('username', 'scott', '10', { domain: 'scott.com', path: '/user' });
+  assert.equal(service.eat('username'), 'scott', 'user name is scott');
+});
+
 test('cookies can be burned', function(assert) {
   assert.expect(3);
   var service = this.subject({


### PR DESCRIPTION
Hey @ScottLNorvell Nice addon!

This PR adds an optional options hash to the `bake()` method.  This is useful for specifying additional cookie options like `domain=`.  
